### PR TITLE
(bower.json) Bump transformers from 0.3.0 to 0.5.5.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "output"
   ],
   "dependencies": {
-    "purescript-transformers": "~0.3.0",
+    "purescript-transformers": "~0.5.5",
     "purescript-timers": "0.0.8",
     "purescript-refs": "~0.1.2"
   }


### PR DESCRIPTION
I ran `pulp test` after bumping this version, which gave all green. I didn't hand-test any functionality, nor hand-check the changes in Transformers, so I don't have high confidence in this version bump. My only goal is to propose this bump to get your opinion. Thoughts?

Why bump? Transformers 0.3 depends on Identity 0.1, which depends on Foldable-traversable 0.1.4, which imports Data.Eq, which can't be found. I heard Data.Eq was part of Prelude in the past but has been removed since then. I'm not sure about Eq's current status.