### PR TITLE
PS 0.7 changes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,8 +12,7 @@
     "output"
   ],
   "dependencies": {
-    "purescript-transformers": "~0.5.5",
-    "purescript-timers": "0.0.8",
-    "purescript-refs": "~0.1.2"
+    "purescript-transformers": "~0.6.1",
+    "purescript-refs": "~0.2.0"
   }
 }

--- a/src/Test/Unit.js
+++ b/src/Test/Unit.js
@@ -1,0 +1,23 @@
+/* global exports */
+"use strict";
+
+// module Test.Unit
+
+exports.exit = function exit(rv) {
+  return function() {
+    try { process.exit(rv); } catch (e) {
+      try { phantom.exit(rv); } catch (e) {}
+    };
+  };
+};
+
+exports.setTimeout = function(duration) {
+  return function(cb) {
+    return function () {
+      setTimeout(function () {
+        cb();
+      }, duration);
+      return {};
+    };
+  };
+};

--- a/src/Test/Unit/Console.js
+++ b/src/Test/Unit/Console.js
@@ -1,0 +1,56 @@
+/* global exports */
+"use strict";
+
+// module Test.Unit.Console
+
+exports.exit = function exit(rv) {
+  return function() {
+    try { process.exit(rv); } catch (e) {
+      try { phantom.exit(rv); } catch (e) {}
+    };
+  };
+};
+
+var hasStderr;
+try { hasStderr = !!process.stderr; } catch (e) { hasStderr = false; }
+exports.hasStderr = hasStderr;
+
+exports.consoleLog = function consoleLog(s) {
+  return function() {
+    console.log(s);
+  };
+};
+exports.consoleError = function consoleError(s) {
+  return function() {
+    console.error(s);
+  };
+};
+exports.savePos = function savePos() {
+  process.stderr.write("\x1b[s");
+};
+exports.restorePos = function restorePos() {
+  process.stderr.write("\x1b[u");
+};
+exports.eraseLine = function eraseLine() {
+  process.stderr.write("\x1b[K");
+};
+exports.print = function print(s) {
+  return function() {
+    process.stderr.write("\x1b[33m" + s + "\x1b[0m");
+  };
+};
+exports.printLabel = function printLabel(s) {
+  return function() {
+    process.stderr.write("\x1b[33;1m" + s + "\x1b[0m");
+  };
+};
+exports.printFail = function printFail(s) {
+  return function() {
+    process.stderr.write("\x1b[31;1m" + s + "\x1b[0m");
+  };
+};
+exports.printPass = function printPass(s) {
+  return function() {
+    process.stderr.write("\x1b[32m" + s + "\x1b[0m");
+  };
+};

--- a/src/Test/Unit/Console.purs
+++ b/src/Test/Unit/Console.purs
@@ -1,67 +1,26 @@
 module Test.Unit.Console where
 
+import Prelude
 import Control.Monad.Eff
 
 foreign import data TestOutput :: !
 
-foreign import hasStderr """
-  var hasStderr;
-  try { hasStderr = !!process.stderr; } catch (e) { hasStderr = false; }
-""" :: Boolean
+foreign import hasStderr :: Boolean
 
-foreign import consoleLog """
-  function consoleLog(s) {
-    return function() {
-      console.log(s);
-    };
-  }""" :: forall e. String -> Eff (testOutput :: TestOutput | e) Unit
+foreign import consoleLog :: forall e. String -> Eff (testOutput :: TestOutput | e) Unit
 
-foreign import consoleError """
-  function consoleError(s) {
-    return function() {
-      console.error(s);
-    };
-  }""" :: forall e. String -> Eff (testOutput :: TestOutput | e) Unit
+foreign import consoleError :: forall e. String -> Eff (testOutput :: TestOutput | e) Unit
 
-foreign import savePos """
-  function savePos() {
-    process.stderr.write("\x1b[s");
-  }""" :: forall e. Eff (testOutput :: TestOutput | e) Unit
+foreign import savePos :: forall e. Eff (testOutput :: TestOutput | e) Unit
 
-foreign import restorePos """
-  function restorePos() {
-    process.stderr.write("\x1b[u");
-  }""" :: forall e. Eff (testOutput :: TestOutput | e) Unit
+foreign import restorePos :: forall e. Eff (testOutput :: TestOutput | e) Unit
 
-foreign import eraseLine """
-  function eraseLine() {
-    process.stderr.write("\x1b[K");
-  }""" :: forall e. Eff (testOutput :: TestOutput | e) Unit
+foreign import eraseLine :: forall e. Eff (testOutput :: TestOutput | e) Unit
 
-foreign import print """
-  function print(s) {
-    return function() {
-      process.stderr.write("\x1b[33m" + s + "\x1b[0m");
-    };
-  }""" :: forall e. String -> Eff (testOutput :: TestOutput | e) Unit
+foreign import print :: forall e. String -> Eff (testOutput :: TestOutput | e) Unit
 
-foreign import printLabel """
-  function printLabel(s) {
-    return function() {
-      process.stderr.write("\x1b[33;1m" + s + "\x1b[0m");
-    };
-  }""" :: forall e. String -> Eff (testOutput :: TestOutput | e) Unit
+foreign import printLabel:: forall e. String -> Eff (testOutput :: TestOutput | e) Unit
 
-foreign import printFail """
-  function printFail(s) {
-    return function() {
-      process.stderr.write("\x1b[31;1m" + s + "\x1b[0m");
-    };
-  }""" :: forall e. String -> Eff (testOutput :: TestOutput | e) Unit
+foreign import printFail :: forall e. String -> Eff (testOutput :: TestOutput | e) Unit
 
-foreign import printPass """
-  function printPass(s) {
-    return function() {
-      process.stderr.write("\x1b[32m" + s + "\x1b[0m");
-    };
-  }""" :: forall e. String -> Eff (testOutput :: TestOutput | e) Unit
+foreign import printPass :: forall e. String -> Eff (testOutput :: TestOutput | e) Unit

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,14 +1,19 @@
 module Test.Main where
 
+import Prelude
 import Control.Monad.Cont.Trans
 import Test.Unit
 
-main = runTest do
-  test "basic asserts" do
-    assert "wasn't true" true
-    assertFalse "wasn't false" false
-  test "async asserts" do
-    testC $ ContT \done -> done success
-    testFn \done -> done success
-    assertC "ContT didn't yield true" $ ContT \done -> done true
-    assertFn "callback didn't receive true" \done -> done true
+main = do
+  runTest do
+    test "basic asserts" do
+      assert "wasn't true" true
+      assertFalse "wasn't false" false
+    test "async asserts" do
+      testC $ ContT \done -> done success
+      testFn \done -> done success
+      assertC "ContT didn't yield true" $ ContT \done -> done true
+      assertFn "callback didn't receive true" \done -> done true
+    test "timeout" do
+      timeout 1000 $ assertC "yielded false" $ ContT (\done -> done true)
+      assert "not true" true


### PR DESCRIPTION
Changes to support 0.7 changes. Updated 2 deps to 0.7 compatible versions.

As purescript-timers doesn't support 0.7 yet and neither does purescript-context, purescript-oo-ffi and the mocha/chai wrappers their tests use, just removed this dependency in favour of doing it here.