### PR TITLE
Fixed process check for browser

### DIFF
--- a/src/Test/Unit/Console.js
+++ b/src/Test/Unit/Console.js
@@ -8,11 +8,9 @@ try { hasStderr = !!process.stderr; } catch (e) { hasStderr = false; }
 exports.hasStderr = hasStderr;
 
 var hasColours = (function() {
-  try {
-    if (!process) {
-      return false;
-    }
-  } catch (e) {}
+  if (typeof process === "undefined") {
+    return false;
+  }
   if (process.stdout && !process.stdout.isTTY) {
     return false;
   }


### PR DESCRIPTION
While running my tests for purescript-webworkers in the browser (since webworkers aren't supported in node) this line was throwing because process is not defined. I think this is a better check to see if there is a "process" variable defined somewhere globally.