### PR TITLE
Update for purescript 0.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /output/
 /.pulp-cache
 *.tix
+.psc-ide-port

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 node_js:
   - "node"
 language: node_js
+env:
+  - PATH=$HOME/purescript:$PATH
 install:
-  - npm install -g purescript pulp bower
+  - wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/v0.11.2/linux64.tar.gz
+  - tar -xvf $HOME/purescript.tar.gz -C $HOME/
+  - chmod a+x $HOME/purescript
+  - npm install -g pulp bower
   - bower install
 script:
   - pulp test

--- a/bower.json
+++ b/bower.json
@@ -16,14 +16,12 @@
     "output"
   ],
   "dependencies": {
-    "purescript-aff": "^2.0.0",
-    "purescript-either": "^2.1.0",
-    "purescript-prelude": "^2.1.0",
-    "purescript-eff": "^2.0.0",
-    "purescript-quickcheck": "^3.1.1",
-    "purescript-free": "^3.0.0",
-    "purescript-strings": "^2.0.1",
-    "purescript-lists": "^3.0.0",
-    "purescript-js-timers": "^2.0.0"
+    "purescript-aff": "^3.0.0",
+    "purescript-prelude": "^3.0.0",
+    "purescript-quickcheck": "^4.0.0",
+    "purescript-free": "^4.0.0",
+    "purescript-strings": "^3.0.0",
+    "purescript-lists": "^4.0.1",
+    "purescript-js-timers": "git://github.com/soupi/purescript-js-timers#1a70d545740493db154d3e4e90345cbc35d498ed"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,6 @@
     "purescript-free": "^4.0.0",
     "purescript-strings": "^3.0.0",
     "purescript-lists": "^4.0.1",
-    "purescript-js-timers": "git://github.com/soupi/purescript-js-timers#1a70d545740493db154d3e4e90345cbc35d498ed"
+    "purescript-js-timers": "^3.0.0"
   }
 }

--- a/src/Test/Unit/Assert.purs
+++ b/src/Test/Unit/Assert.purs
@@ -32,7 +32,7 @@ expectFailure reason t = do
   either (const success) (const $ failure reason) r
 
 -- | Assert that two printable values are equal.
-equal :: forall a e. (Eq a, Show a) => a -> a -> Test e
+equal :: forall a e. (Eq a) => (Show a) => a -> a -> Test e
 equal expected actual =
   if expected == actual then success
   else failure $ "expected " <> show expected <>
@@ -49,5 +49,5 @@ equal' reason expected actual =
 -- |
 -- |     it "should do what I expect of it" do
 -- |       result `shouldEqual` "expected result"
-shouldEqual :: forall a e. (Eq a, Show a) => a -> a -> Test e
+shouldEqual :: forall a e. (Eq a) => (Show a) => a -> a -> Test e
 shouldEqual = flip equal

--- a/src/Test/Unit/Console.purs
+++ b/src/Test/Unit/Console.purs
@@ -1,9 +1,9 @@
 module Test.Unit.Console where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Control.Monad.Eff (Eff, kind Effect)
 
-foreign import data TESTOUTPUT :: !
+foreign import data TESTOUTPUT :: Effect
 
 foreign import hasStderr :: Boolean
 

--- a/src/Test/Unit/Main.purs
+++ b/src/Test/Unit/Main.purs
@@ -25,7 +25,7 @@ foreign import exit :: forall e. Int -> Eff (console :: CONSOLE | e) Unit
 
 run :: forall e. Aff (console :: CONSOLE | e) Unit -> Eff (console :: CONSOLE | e) Unit
 run e = do
-  runAff errorHandler successHandler e
+  _ <- runAff errorHandler successHandler e
   pure unit
   where errorHandler _ = exit 1
         successHandler _ = pure unit

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -47,9 +47,9 @@ tests = do
 
 main :: forall e. Eff (timer :: TIMER, avar :: AVAR, console :: CONSOLE, random :: RANDOM, testOutput :: TESTOUTPUT | e) Unit
 main = run do
-  resetRef
+  _ <- resetRef
   runTestWith Fancy.runTest tests
-  resetRef
+  _ <- resetRef
   runTestWith Simple.runTest tests
-  resetRef
+  _ <- resetRef
   runTestWith TAP.runTest tests


### PR DESCRIPTION
I had to pull `purescript-js-timers` from a fork that has yet to be merged, but other than that, I think these changes should make `test-unit` compatible with 0.11.x.

I'll comment when I notice that `purescript-js-timers` update has been merged.