### PR TITLE
suiteSkip, suiteOnly, testSkip, testOnly

### DIFF
--- a/src/Test/Unit.purs
+++ b/src/Test/Unit.purs
@@ -4,12 +4,19 @@ module Test.Unit
   , Group(..)
   , TestSuite
   , TestList
+  , Skip(..)
+  , Only(..)
   , success
   , failure
   , timeout
   , test
+  , testOnly
+  , testSkip
   , suite
+  , suiteOnly
+  , suiteSkip
   , walkSuite
+  , filterTests
   , collectTests
   , collectResults
   , keepErrors
@@ -18,14 +25,19 @@ module Test.Unit
   ) where
 
 import Prelude
+
 import Control.Monad.Aff (Aff, attempt, makeAff, forkAff, cancelWith)
 import Control.Monad.Aff.AVar (modifyVar, makeVar', makeVar, killVar, putVar, takeVar, AVAR)
 import Control.Monad.Eff.Exception (error, Error)
 import Control.Monad.Eff.Timer (TIMER, setTimeout)
-import Control.Monad.Free (runFreeM, Free, liftF)
+import Control.Monad.Free (Free, foldFree, liftF, runFreeM)
+import Control.Monad.State (State, execState)
+import Control.Monad.State.Class (modify)
 import Data.Either (Either(Left), either)
 import Data.Foldable (foldl)
+import Data.HeytingAlgebra (ff, implies)
 import Data.List (snoc, List(Cons, Nil))
+import Data.Newtype (class Newtype, over, over2, un)
 import Data.Traversable (for)
 import Data.Tuple (Tuple(Tuple))
 
@@ -55,29 +67,113 @@ pickFirst t1 t2 = do
 timeout :: forall e. Int -> Test (timer :: TIMER, avar :: AVAR | e) -> Test (timer :: TIMER, avar :: AVAR | e)
 timeout time t = t `pickFirst` (makeTimeout time)
 
+newtype Skip = Skip Boolean
 
+derive instance newtypeSkip :: Newtype Skip _
+
+newtype Only = Only Boolean
+
+derive instance newtypeOnly :: Newtype Only _
+
+instance showOnly :: Show Only where
+  show (Only b) = show b
+
+instance haytingAlgebraOnly :: HeytingAlgebra Only where
+  ff = Only false
+  tt = Only true
+  implies = over2 Only implies
+  conj = over2 Only conj
+  disj = over2 Only disj
+  not = over Only not
 
 data Group e = Group String (TestSuite e)
 
-data TestF e a = TestGroup (Group e) a
-               | TestUnit String (Test e) a
+data TestF e a = TestGroup (Group e) Skip Only a
+               | TestUnit String Skip Only (Test e) a
+               | SkipUnit a
 
 type TestSuite e = Free (TestF e) Unit
 
+skipUnit :: forall a e. a -> Free (TestF e) a
+skipUnit = liftF <<< SkipUnit
+
 instance functorTestF :: Functor (TestF e) where
-  map f (TestGroup g a) = TestGroup g (f a)
-  map f (TestUnit l t a) = TestUnit l t (f a)
+  map f (TestGroup g s o a) = TestGroup g s o (f a)
+  map f (TestUnit l s o t a) = TestUnit l s o t (f a)
+  map f (SkipUnit a) = SkipUnit (f a)
 
 -- | Define a test suite, which can contain a number of nested suites
 -- | as well as tests.
 suite :: forall e. String -> TestSuite e -> TestSuite e
-suite label tests = liftF $ TestGroup (Group label tests) unit
+suite label tests = liftF $ TestGroup (Group label tests) (Skip false) (Only false) unit
+
+-- | Run only this suite.
+suiteOnly :: forall e. String -> TestSuite e -> TestSuite e
+suiteOnly label tests = liftF $ TestGroup (Group label tests) (Skip false) (Only true) unit
+
+-- | Skip this suite.
+suiteSkip :: forall e. String -> TestSuite e -> TestSuite e
+suiteSkip label tests = liftF $ TestGroup (Group label tests) (Skip true) (Only false) unit
 
 -- | Define a labelled test.
 test :: forall e. String -> Test e -> TestSuite e
-test l t = liftF $ TestUnit l (memoise t) unit
+test l t = liftF $ TestUnit l (Skip false) (Only false) (memoise t) unit
 
+-- | Run only this test.
+testOnly :: forall e. String -> Test e -> TestSuite e
+testOnly l t = liftF $ TestUnit l (Skip false) (Only true) (memoise t) unit
 
+-- | Skip a test.
+testSkip :: forall e. String -> Test e -> TestSuite e
+testSkip l t = liftF $ TestUnit l (Skip true) (Only false) (memoise t) unit
+
+-- | Find if there are suites and tests with `Only true` flag.
+-- | Returns a tuple where the first factor is `Only true` iff there is a suite
+-- | with only flag set to true, and the second factor is `Only true` iff there
+-- | is a test with only flag set to true.
+hasOnly :: forall a e. Free (TestF e) a -> Tuple Only Only
+hasOnly t = execState (foldFree go t) ff
+  where
+    go :: TestF e ~> State (Tuple Only Only)
+    go (TestGroup (Group _ t') _ only r) = modify (disj (hasOnly t') <<< disj (Tuple only ff)) $> r
+    go (TestUnit _ _ only _ r) = modify (disj (Tuple ff only)) $> r
+    go (SkipUnit r) = pure r
+
+filterEmptyNodes :: forall e. Free (TestF e) ~> Free (TestF e)
+filterEmptyNodes = runFreeM go
+  where
+
+    go :: TestF e ~> Free (TestF e)
+    go tg@(TestGroup (Group _ t) _ _ r) | isEmpty t = skipUnit r
+                                        | otherwise = liftF tg
+    go t = liftF t
+
+    isEmpty :: forall a. Free (TestF e) a -> Boolean
+    isEmpty t = execState (foldFree empty t) true
+
+    empty :: TestF e ~> State Boolean 
+    empty tg@(TestGroup (Group _ t) _ _ r) = modify (conj $ isEmpty t) $> r
+    empty (TestUnit _ _ _ _ r) = modify (conj false) $> r
+    empty (SkipUnit r) = pure r
+
+-- | Filter suites and tests with `Only` and `Skip` flags and removes suites
+-- | that do not contain any tests.
+filterTests :: forall e. Free (TestF e) ~> Free (TestF e)
+filterTests t =
+  let Tuple os ot = hasOnly t
+
+      go :: Only -> TestF e ~> Free (TestF e)
+      go _ tg@(TestGroup (Group n t') s o a)
+        = if un Skip s
+            then skipUnit a
+            else liftF $ TestGroup (Group n (runFreeM (go o) t')) s o a
+      go inOnly tu@(TestUnit n s o t' a)
+        = case un Only (os `implies` inOnly && ot `implies` o) && not (un Skip s) of
+            true  -> liftF tu
+            false -> skipUnit a
+      go _ su@(SkipUnit a)  = liftF su
+
+  in filterEmptyNodes $ runFreeM (go (Only false)) t
 
 -- | A list of collected tests, represented as a tuple of each test's path
 -- | and the `Test` itself. The path, in this case, means the name of the
@@ -90,13 +186,15 @@ type TestList e = List (Tuple (List String) (Test e))
 walkSuite :: forall e. (List String -> TestF (avar :: AVAR | e) (TestSuite (avar :: AVAR | e)) -> Aff (avar :: AVAR | e) Unit) -> TestSuite (avar :: AVAR | e) -> Aff (avar :: AVAR | e) (TestList (avar :: AVAR | e))
 walkSuite runItem tests = do
   coll <- makeVar' Nil
-  let walkItem path group@(TestGroup (Group label content) rest) = do
+  let walkItem path group@(TestGroup (Group label content) skip only rest) = do
         runItem path group
         runFreeM (walkItem (snoc path label)) content
         pure rest
-      walkItem path t@(TestUnit label aff rest) = do
+      walkItem path t@(TestUnit label skip only aff rest) = do
         modifyVar (Cons (Tuple (snoc path label) aff)) coll
         runItem path t
+        pure rest
+      walkItem path (SkipUnit rest) = do
         pure rest
   runFreeM (walkItem Nil) tests
   res <- takeVar coll
@@ -105,7 +203,7 @@ walkSuite runItem tests = do
 -- | Walk through a test suite, returning a `TestList` of all tests walked.
 -- | This operation will not actually run the tests.
 collectTests :: forall e. TestSuite (avar :: AVAR | e) -> Aff (avar :: AVAR | e) (TestList (avar :: AVAR | e))
-collectTests = walkSuite (\_ _ -> pure unit)
+collectTests t = walkSuite (\_ _ -> pure unit) t
 
 -- | Run a list of tests and collect each test result.
 collectResults :: forall e. TestList e -> Aff e (List (Tuple (List String) (Either Error Unit)))
@@ -119,13 +217,28 @@ keepErrors = foldl run Nil
         run s _ = s
 
 
-
 -- Some aliases to keep Dan North happy.
 
 -- | `describe` is an alias for `suite` for BDD enthusiasts.
 describe :: forall e. String -> TestSuite e -> TestSuite e
 describe = suite
 
+-- | `fdescribe` is an alias for `suiteOnly`.
+fdescribe :: forall e. String -> TestSuite e -> TestSuite e
+fdescribe = suiteOnly
+
+-- | `xdescribe` is an alias for `suiteSkip`.
+xdescribe :: forall e. String -> TestSuite e -> TestSuite e
+xdescribe = suiteSkip
+
 -- | `it` is an alias for `test` for BDD enthusiasts.
 it :: forall e. String -> Test e -> TestSuite e
 it = test
+
+-- | `fit` is an alias for `testOnly`.
+fit :: forall e. String -> Test e -> TestSuite e
+fit = testOnly
+
+-- | `xit` is an alias for `testSkip`.
+xit :: forall e. String -> Test e -> TestSuite e
+xit = testSkip

--- a/src/Test/Unit/Main.purs
+++ b/src/Test/Unit/Main.purs
@@ -13,7 +13,7 @@ import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE)
 import Data.List (length)
-import Test.Unit (TestList, TestSuite, collectResults, filterTests, keepErrors)
+import Test.Unit (TestList, TestSuite, collectResults, countSkippedTests, filterTests, keepErrors)
 import Test.Unit.Console (hasColours, hasStderr, TESTOUTPUT)
 import Test.Unit.Output.Fancy as Fancy
 import Test.Unit.Output.Simple as Simple

--- a/src/Test/Unit/Main.purs
+++ b/src/Test/Unit/Main.purs
@@ -6,17 +6,18 @@ module Test.Unit.Main
   ) where
 
 import Prelude
-import Test.Unit.Output.Fancy as Fancy
-import Test.Unit.Output.Simple as Simple
-import Test.Unit.Output.TAP as TAP
+
 import Control.Monad.Aff (runAff, Aff)
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE)
 import Data.List (length)
-import Test.Unit (collectResults, TestList, keepErrors, TestSuite)
+import Test.Unit (TestList, TestSuite, collectResults, filterTests, keepErrors)
 import Test.Unit.Console (hasColours, hasStderr, TESTOUTPUT)
+import Test.Unit.Output.Fancy as Fancy
+import Test.Unit.Output.Simple as Simple
+import Test.Unit.Output.TAP as TAP
 
 -- | Exit the current process using the provided return code.
 -- |
@@ -33,7 +34,7 @@ run e = do
 -- | Run a test suite using the provided test runner.
 runTestWith  :: forall e. (TestSuite (console :: CONSOLE | e) -> Aff (console :: CONSOLE | e) (TestList (console :: CONSOLE | e))) -> TestSuite (console :: CONSOLE | e) -> Aff (console :: CONSOLE | e) Unit
 runTestWith runner suite = do
-  results <- runner suite >>= collectResults
+  results <- runner (filterTests suite) >>= collectResults
   let errs = keepErrors results
   if length errs > 0 then liftEff (exit 1) else pure unit
 

--- a/src/Test/Unit/Output/Fancy.purs
+++ b/src/Test/Unit/Output/Fancy.purs
@@ -3,6 +3,7 @@ module Test.Unit.Output.Fancy
   ) where
 
 import Prelude
+
 import Control.Monad.Aff (attempt, Aff)
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff.Class (liftEff)
@@ -13,7 +14,7 @@ import Data.List (List, uncons, length)
 import Data.Maybe (Maybe(Just, Nothing), maybe)
 import Data.Monoid (mempty)
 import Data.Tuple (Tuple(Tuple))
-import Test.Unit (collectResults, TestList, keepErrors, walkSuite, TestF(..), TestSuite, Group(..))
+import Test.Unit (Group(..), TestF(..), TestList, TestSuite, collectResults, keepErrors, walkSuite)
 import Test.Unit.Console (printFail, savePos, restorePos, eraseLine, printPass, printLabel, print, TESTOUTPUT)
 
 indent :: Int -> String
@@ -26,13 +27,13 @@ indent' = length >>> indent
 printLive :: forall e. TestSuite (testOutput :: TESTOUTPUT, avar :: AVAR | e) -> Aff (testOutput :: TESTOUTPUT, avar :: AVAR | e) (TestList (testOutput :: TESTOUTPUT, avar :: AVAR | e))
 printLive tst = walkSuite runSuiteItem tst
   where
-    runSuiteItem path (TestGroup (Group label content) rest) = do
+    runSuiteItem path (TestGroup (Group label content) skip only rest) = do
       liftEff do
         print $ indent' path
         print "\x2192 Suite: "
         printLabel label
         void $ print "\n"
-    runSuiteItem path (TestUnit label t rest) = do
+    runSuiteItem path (TestUnit label _ _ t rest) = do
       liftEff do
         print $ indent' path
         savePos
@@ -53,6 +54,8 @@ printLive tst = walkSuite runSuiteItem tst
           print " because "
           printFail $ message err
           print "\n"
+    runSuiteItem _ (SkipUnit _) = pure unit
+
 
 printErrors :: forall e. TestList (testOutput :: TESTOUTPUT | e) -> Aff (testOutput :: TESTOUTPUT | e) Unit
 printErrors tests = do

--- a/src/Test/Unit/Output/Simple.purs
+++ b/src/Test/Unit/Output/Simple.purs
@@ -15,7 +15,7 @@ import Data.List (length, List, uncons)
 import Data.Maybe (Maybe(Just, Nothing), fromMaybe)
 import Data.Monoid (mempty)
 import Data.Tuple (Tuple(Tuple))
-import Test.Unit (Group(..), TestF(..), TestList, TestSuite, collectResults, keepErrors, walkSuite)
+import Test.Unit (Group(..), TestF(..), TestList, TestSuite, collectResults, countSkippedTests, keepErrors, walkSuite)
 
 indent :: Int -> String
 indent 0 = mempty
@@ -38,20 +38,24 @@ printLive tst = walkSuite runSuiteItem tst
           log $ indent' path <> "\x2620 Failed: " <> label
                              <> " because " <> message err
       pure unit
-    runSuiteItem _ (SkipUnit _) = pure unit
+    runSuiteItem _ (SkipUnit _ _) = pure unit
 
-printErrors :: forall e. TestList (console :: CONSOLE | e) -> Aff (console :: CONSOLE | e) Unit
-printErrors tests = do
+printErrors :: forall e. TestList (console :: CONSOLE | e) -> Int -> Aff (console :: CONSOLE | e) Unit
+printErrors tests skCount = do
   results <- collectResults tests
   let errors = keepErrors results
+      skMsg = case skCount of
+          0 -> ""
+          1 -> " (1 test skipped)"
+          i -> " (" <> show i <> " tests skipped)"
   log ""
   case length errors of
-    0 -> log $ "All " <> show (length results) <> " tests passed!\n"
+    0 -> log $ "All " <> show (length results) <> " tests passed" <> skMsg <> "!"
     1 -> do
-      log "1 test failed:\n"
+      log $ "1 test failed" <> skMsg <> ":\n"
       list errors
     i -> do
-      log $ show i <> " tests failed:\n"
+      log $ show i <> " tests failed" <> skMsg <> ":\n"
       list errors
   where list = traverse_ print
         print (Tuple path err) = do
@@ -68,5 +72,5 @@ printErrors tests = do
 runTest :: forall e. TestSuite (console :: CONSOLE, avar :: AVAR | e) -> Aff (console :: CONSOLE, avar :: AVAR | e) (TestList (console :: CONSOLE, avar :: AVAR | e))
 runTest suite = do
   tests <- printLive suite
-  printErrors tests
+  printErrors tests (countSkippedTests suite)
   pure tests

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,20 +1,22 @@
 module Test.Main where
 
 import Prelude
-import Test.Unit.Assert as Assert
-import Test.Unit.Output.Fancy as Fancy
-import Test.Unit.Output.Simple as Simple
-import Test.Unit.Output.TAP as TAP
+
 import Control.Monad.Aff (Aff, makeAff)
-import Control.Monad.Aff.AVar (AVAR)
+import Control.Monad.Aff.AVar (AVAR, AVar, makeVar, makeVar', modifyVar, putVar, tryTakeVar)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.Random (RANDOM)
 import Control.Monad.Eff.Timer (TIMER)
+import Data.Maybe (Maybe(Just))
 import Test.QuickCheck (Result, (===))
-import Test.Unit (TestSuite, suite, Test, test, timeout)
+import Test.Unit (Test, TestSuite, failure, suite, suiteOnly, suiteSkip, test, testOnly, testSkip, timeout)
+import Test.Unit.Assert as Assert
 import Test.Unit.Console (TESTOUTPUT)
 import Test.Unit.Main (runTestWith, run)
+import Test.Unit.Output.Fancy as Fancy
+import Test.Unit.Output.Simple as Simple
+import Test.Unit.Output.TAP as TAP
 import Test.Unit.QuickCheck (quickCheck)
 
 unresolved :: forall e. Test e
@@ -36,10 +38,15 @@ tests = do
   test "equal" do
     Assert.equal "omg" "omg"
     Assert.expectFailure "should be unequal" $ Assert.equal "omg" "wat"
-  test "quickcheck" do
+  test"quickcheck" do
     quickCheck theCommutativeProperty
   suite "a test suite" do
     test "a test in a test suite" do
+      pure unit
+  suite "another suite" do
+    test "this should not run" do
+      pure unit
+    test "a test in another test suite" do
       pure unit
   test "tests run only once" do
     ref <- incRef
@@ -53,3 +60,73 @@ main = run do
   runTestWith Simple.runTest tests
   _ <- resetRef
   runTestWith TAP.runTest tests
+  _ <- resetRef
+
+  var1 <- makeVar' 0
+  runTestWith Fancy.runTest do
+    testSkip "skip 1" do
+      failure "skippedTestError"
+    suiteSkip "skipped suite" do
+      test "skip 2" do
+        failure "skippedTestError"
+      suite "also skipped" do
+        test "skip 3" do
+          failure "skippedTestError"
+    suite "not skipped suite" do
+      test "not skipped test" do
+        modifyVar (add 1) var1
+        pure unit
+      suiteSkip "skipped subsuite" do
+        test "skip 3" do
+          failure "skippedTestError"
+      suite "not skipped inner suite" do
+        test "also not skipped" do
+          modifyVar (add 1) var1
+          pure unit
+
+  runTestWith Fancy.runTest do
+    test "all not skipped tests were executed" do
+      val <- tryTakeVar var1
+      Assert.equal (Just 2) val
+
+  var2 <- makeVar' 0
+  runTestWith Fancy.runTest do
+    testOnly "only 1" do
+      modifyVar (add 1) var2
+      pure unit
+    test "skipped 1" do
+      failure "onlyTestError"
+    suite "suite" do
+      test "skipped 2" do
+        failure "onlyTestError"
+      testOnly "only 2" do
+        modifyVar (add 1) var2
+        pure unit
+    suite "empty suite" do
+      test "skipped 3" do
+        failure "onlyTestError"
+      test "skipped 4" do
+        failure "onlyTestError"
+
+  runTestWith Fancy.runTest do
+    test "all `testOnly` tests where executed" do
+      val <- tryTakeVar (var2 :: AVar Int)
+      Assert.equal (Just 2) val
+
+  var3 <- makeVar
+  runTestWith Fancy.runTest do
+    suiteOnly "only suite" do
+      test "test 1" do
+        pure unit
+    suite "skipped suite" do
+      test "skipped test" do
+        failure "onlyTestError"
+      suiteOnly "only suite 2" do
+        test "this test will run" do
+          putVar var3 true
+          pure unit
+
+  runTestWith Fancy.runTest do
+    test "inner suite run" do
+      val <- tryTakeVar (var3 :: AVar Boolean)
+      Assert.equal (Just true) val


### PR DESCRIPTION
Add commands which allow to skip tests / suites or execute only given
tests / suites.

* `suiteSkip` and `testSkip` - will be skipped
* `suiteOnly` - if there is at least one `suiteOnly` suite, only tests
    from these suites will be executed
* `testOnly` - if there is at least one `testOnly` test, only test that
    are explicitly marked as `Only true` will run.

PR includes tests.  Any suggestion for better command names?