### PR TITLE
Added TestEffects type

### DIFF
--- a/src/Test/Unit.purs
+++ b/src/Test/Unit.purs
@@ -1,5 +1,6 @@
 module Test.Unit
   ( Test(..)
+  , TestEffects(..)
   , TestF(..)
   , Group(..)
   , TestSuite
@@ -30,6 +31,7 @@ import Prelude
 import Control.Monad.Aff (Aff, attempt, makeAff, forkAff, cancelWith)
 import Control.Monad.Aff.AVar (modifyVar, makeVar', makeVar, killVar, putVar, takeVar, AVAR)
 import Control.Monad.Eff.Exception (error, Error)
+import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.Timer (TIMER, setTimeout)
 import Control.Monad.Free (Free, foldFree, liftF, runFreeM, substFree)
 import Control.Monad.State (State, execState)
@@ -41,10 +43,12 @@ import Data.List (snoc, List(Cons, Nil))
 import Data.Newtype (class Newtype, over, over2, un)
 import Data.Traversable (for)
 import Data.Tuple (Tuple(Tuple))
+import Test.Unit.Console (TESTOUTPUT)
 
 foreign import memoise :: forall a e. Aff e a -> Aff e a
 
 type Test e = Aff e Unit
+type TestEffects e = (console :: CONSOLE, testOutput :: TESTOUTPUT, avar :: AVAR | e)
 
 -- | The basic value for a succeeding test.
 success :: forall e. Test e

--- a/src/Test/Unit/Main.purs
+++ b/src/Test/Unit/Main.purs
@@ -13,7 +13,7 @@ import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE)
 import Data.List (length)
-import Test.Unit (TestList, TestSuite, collectResults, countSkippedTests, filterTests, keepErrors)
+import Test.Unit (TestList, TestSuite, collectResults, filterTests, keepErrors)
 import Test.Unit.Console (hasColours, hasStderr, TESTOUTPUT)
 import Test.Unit.Output.Fancy as Fancy
 import Test.Unit.Output.Simple as Simple

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,14 +5,12 @@ import Prelude
 import Control.Monad.Aff (Aff, makeAff)
 import Control.Monad.Aff.AVar (AVAR, AVar, makeVar, makeVar', modifyVar, putVar, tryTakeVar)
 import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.Random (RANDOM)
 import Control.Monad.Eff.Timer (TIMER)
 import Data.Maybe (Maybe(Just))
 import Test.QuickCheck (Result, (===))
-import Test.Unit (Test, TestSuite, failure, suite, suiteOnly, suiteSkip, test, testOnly, testSkip, timeout)
+import Test.Unit (Test, TestEffects, TestSuite, failure, suite, suiteOnly, suiteSkip, test, testOnly, testSkip, timeout)
 import Test.Unit.Assert as Assert
-import Test.Unit.Console (TESTOUTPUT)
 import Test.Unit.Main (runTestWith, run)
 import Test.Unit.Output.Fancy as Fancy
 import Test.Unit.Output.Simple as Simple
@@ -52,7 +50,7 @@ tests = do
     ref <- incRef
     Assert.equal 1 ref
 
-main :: forall e. Eff (timer :: TIMER, avar :: AVAR, console :: CONSOLE, random :: RANDOM, testOutput :: TESTOUTPUT | e) Unit
+main :: forall e. Eff (TestEffects (timer :: TIMER, random :: RANDOM | e)) Unit
 main = run do
   _ <- resetRef
   runTestWith Fancy.runTest tests


### PR DESCRIPTION
I added a `TestEffects` type as sugar so you don't have to import all of those effects and to reduce the verbosity of the type signature.

So it looks like this:
```purescript
main :: Eff (TestEffects ()) Unit
main = runTest do
  describe "2 + 2" do
    it "should equal 4" do
      (2 + 2) `shouldEqual` 4
```