### PR TITLE
Export equal''

### DIFF
--- a/src/Test/Unit/Assert.purs
+++ b/src/Test/Unit/Assert.purs
@@ -4,6 +4,7 @@ module Test.Unit.Assert
   , expectFailure
   , equal
   , equal'
+  , equal''
   , shouldEqual
   ) where
 


### PR DESCRIPTION
There's a very handy `equal''` already in Assert module, so let's export it.