### PR TITLE
Add FancyNoStack output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ with:
 main = run $ runTestWith Test.Unit.Output.TAP.runTest do --...
 ```
 
+To show "fancy" output without dumping the JavaScript stack, use the `FancyNoStack` runner:
+```purescript
+main = run $ runTestWith Test.Unit.Output.FancyNoStack.runTest do --...
+```
+
 You may also supply your own custom test runner - study one of the existing test runners to learn how.
 
 ## Licence

--- a/README.md
+++ b/README.md
@@ -6,19 +6,11 @@ An asynchronous unit test runner for PureScript.
 
 ## Usage
 
-Test-Unit tests are simply
-[Aff](https://github.com/slamdata/purescript-aff) actions, which can
-either succeed (test passed) or fail (test did not pass). The type for
-these tests is `Test`, which is just an alias for `Aff Unit`.
+Test-Unit tests are simply [Aff](https://github.com/slamdata/purescript-aff) actions, which can either succeed (test passed) or fail (test did not pass). The type for these tests is `Test`, which is just an alias for `Aff Unit`.
 
-The `Test.Unit.Assert` module contains a number of functions for
-making common assertions. The most straightforward is `assert`, which
-takes a failure message and a boolean, and if the boolean is true, it
-produces a `Test` which immediately succeeds. If the boolean is false,
-you get a `Test` which fails with the provided error message.
+The `Test.Unit.Assert` module contains a number of functions for making common assertions. The most straightforward is `assert`, which takes a failure message and a boolean, and if the boolean is true, it produces a `Test` which immediately succeeds. If the boolean is false, you get a `Test` which fails with the provided error message.
 
-Because tests are really just `Aff`s, you can perform any `Aff` inside
-a do block, allowing you to easily test asynchronous code.
+Because tests are really just `Aff`s, you can perform any `Aff` inside a do block, allowing you to easily test asynchronous code.
 
 ```purescript
 module Test.Main where
@@ -49,16 +41,11 @@ main = runTest do
         Assert.equal "can we read a file in 100ms?\n" file2Contents
 ```
 
-Run tests using [`pulp test`](https://github.com/bodil/pulp) or just
-by compiling with `--main Test.Main`.
+Run tests using [`pulp test`](https://github.com/bodil/pulp) or just by compiling with `--main Test.Main`.
 
 ## QuickCheck
 
-[purescript-quickcheck](https://github.com/purescript/purescript-quickcheck)
-tests can be run using the functions in the `Test.Unit.QuickCheck`
-module. It exports two functions, `quickCheck` and `quickCheck'`,
-which work like their QuickCheck counterparts, except they produce
-`Test` actions so they integrate cleanly with Test-Unit.
+[purescript-quickcheck](https://github.com/purescript/purescript-quickcheck) tests can be run using the functions in the `Test.Unit.QuickCheck` module. It exports two functions, `quickCheck` and `quickCheck'`, which work like their QuickCheck counterparts, except they produce `Test` actions so they integrate cleanly with Test-Unit.
 
 ```purescript
 module Test.Main where
@@ -81,45 +68,36 @@ main = runTest do
 
 ## Output Formats
 
-The `Test.Unit.Main.runTest` function will default to simple output of
-test results using `console.log` (the
-`Test.Unit.Output.Simple.runTest` test runner). If you're running on
-an ANSI colour capable terminal, it will use the
-`Test.Unit.Output.Fancy.runTest` test runner, which gets a little more
-colourful.
+The `Test.Unit.Main.runTest` function will default to simple output of test results using `console.log` (the `Test.Unit.Output.Simple.runTest` test runner). If you're running on an ANSI colour capable terminal, it will use the `Test.Unit.Output.Fancy.runTest` test runner, which gets a little more colourful.
 
-Additionally, if `Test.Unit.Main.runTest` notices the word `tap` or
-`--tap` on its command line, it will pick the
-`Test.Unit.Output.TAP.runTest` test runner, which outputs test results
-using the [TAP](https://testanything.org/) format. A number of TAP
-consumers are
-[available on NPM](https://www.npmjs.com/package/tape#pretty-reporters)
-to transform the test output. For instance, you could install the
-[tap-spec](https://github.com/scottcorgan/tap-spec) and run your tests
-like this: `pulp test tap | tap-spec`.
+Additionally, if `Test.Unit.Main.runTest` notices the word `tap` or `--tap` on its command line, it will pick the `Test.Unit.Output.TAP.runTest` test runner, which outputs test results using the [TAP](https://testanything.org/) format. A number of TAP consumers are [available on NPM](https://www.npmjs.com/package/tape#pretty-reporters) to transform the test output. For instance, you could install the [tap-spec](https://github.com/scottcorgan/tap-spec) and run your tests like this:
 
-You can also specify your own test runner using the
-`Test.Unit.Main.runTestWith` function, which takes a test runner as
-its first argument. So, if you want to force the TAP test runner,
-instead of `main = runTest do ...` you could use `main = runTestWith
-Test.Unit.Output.TAP.runTest do ...`. You could also supply your own
-custom test runner - study one of the existing test runners to learn
-how.
+```
+pulp test tap | tap-spec
+```
+
+or with `spago`:
+```
+spago test --node-args tap
+```
+
+You can also specify the test runner using the `Test.Unit.Main.runTestWith` function, which takes a test runner as its first argument. So, if you want to force the TAP test runner, replace:
+```purescript
+main = runTest do --...
+```
+with:
+```purescript
+main = run $ runTestWith Test.Unit.Output.TAP.runTest do --...
+```
+
+You may also supply your own custom test runner - study one of the existing test runners to learn how.
 
 ## Licence
 
 Copyright 2014 Bodil Stokke
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-Lesser General Public License for more details.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public
-License along with this program. If not, see
-<http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License along with this program. If not, see <http://www.gnu.org/licenses/>.

--- a/src/Test/Unit/Output/FancyNoStack.purs
+++ b/src/Test/Unit/Output/FancyNoStack.purs
@@ -1,0 +1,96 @@
+module Test.Unit.Output.FancyNoStack
+  ( runTest
+  ) where
+
+import Prelude
+import Effect.Aff (attempt, Aff)
+import Effect.Class (liftEffect)
+import Effect.Exception (message)
+import Data.Either (Either(Left, Right))
+import Data.Foldable (traverse_)
+import Data.List (List, uncons, length)
+import Data.Maybe (Maybe(Just, Nothing))
+import Data.Tuple (Tuple(Tuple))
+import Test.Unit (TestList, TestSuite, collectResults, countSkippedTests, keepErrors, walkSuite)
+import Test.Unit.Console (printFail, savePos, restorePos, eraseLine, printPass, printLabel, print)
+
+indent :: Int -> String
+indent 0 = mempty
+
+indent n = "  " <> indent (n - 1)
+
+indent' :: forall a. List a -> String
+indent' = length >>> indent
+
+printLive :: TestSuite -> Aff TestList
+printLive tst = walkSuite runSuiteItem tst
+  where
+  runSuiteItem path (Left label) = do
+    liftEffect do
+      print $ indent' path
+      print "\x2192 Suite: "
+      printLabel label
+      void $ print "\n"
+
+  runSuiteItem path (Right (Tuple label t)) = do
+    liftEffect do
+      print $ indent' path
+      savePos
+      print "\x2192 Running: "
+      printLabel label
+      restorePos
+    result <- attempt t
+    void
+      $ case result of
+          (Right _) ->
+            liftEffect do
+              eraseLine
+              printPass "\x2713 Passed: "
+              printLabel label
+              print "\n"
+          (Left err) ->
+            liftEffect do
+              eraseLine
+              printFail "\x2620 Failed: "
+              printLabel label
+              print " because "
+              printFail $ message err
+              print "\n"
+
+printErrors :: TestList -> Int -> Aff Unit
+printErrors tests skCount = do
+  results <- collectResults tests
+  let
+    errors = keepErrors results
+
+    skMsg = case skCount of
+      0 -> ""
+      1 -> " (1 test skipped)"
+      i -> " (" <> show i <> " tests skipped)"
+  liftEffect do
+    case length errors of
+      0 -> printPass $ "\nAll " <> show (length results) <> " tests passed" <> skMsg <> "! 🎉\n"
+      1 -> do
+        printFail $ "\n1 test failed" <> skMsg <> ":\n\n"
+        list errors
+      i -> do
+        printFail $ "\n" <> show i <> " tests failed" <> skMsg <> ":\n\n"
+        list errors
+  where
+  list = traverse_ printItem
+
+  printItem (Tuple path err) = do
+    printHeader 0 path
+    printFail $ message err <> "\n\n"
+
+  printHeader level path = case uncons path of
+    Nothing -> print $ indent level
+    Just { head, tail } -> do
+      print $ indent level <> "In \"" <> head <> "\":\n"
+      printHeader (level + 1) tail
+
+runTest :: TestSuite -> Aff TestList
+runTest suite = do
+  tests <- printLive suite
+  printErrors tests (countSkippedTests suite)
+  pure tests

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -10,6 +10,7 @@ import Test.Unit (TestSuite, failure, suite, suiteOnly, suiteSkip, test, testOnl
 import Test.Unit.Assert as Assert
 import Test.Unit.Main (runTestWith, run)
 import Test.Unit.Output.Fancy as Fancy
+import Test.Unit.Output.FancyNoStack as FancyNoStack
 import Test.Unit.Output.Simple as Simple
 import Test.Unit.Output.TAP as TAP
 import Test.Unit.QuickCheck (quickCheck)
@@ -49,6 +50,8 @@ main :: Effect Unit
 main = run do
   ref <- liftEffect $ Ref.new 0
   runTestWith Fancy.runTest $ tests ref
+  liftEffect $ Ref.write 0 ref
+  runTestWith FancyNoStack.runTest $ tests ref
   liftEffect $ Ref.write 0 ref
   runTestWith Simple.runTest $ tests ref
   liftEffect $ Ref.write 0 ref


### PR DESCRIPTION
This is intended to be merged after #46. 

The existing test output is pretty noisy. I don't think most users are concerned with viewing the JavaScript stack for each error:
```
☠ Failed: first because expected 1, got 2
✓ Passed: second
☠ Failed: third because expected 1, got 3

2 tests failed:

In "third":
  Error: expected 1, got 3
    at Object.exports.error (/home/miles/temp/tt/clean-error/output/Effect.Exception/foreign.js:8:10)
    at Object.failure (/home/miles/temp/tt/clean-error/output/Test.Unit/index.js:309:38)
    at /home/miles/temp/tt/clean-error/output/Test.Unit.Assert/index.js:40:34
    at /home/miles/temp/tt/clean-error/output/Test.Main/index.js:18:99
    at $tco_loop (/home/miles/temp/tt/clean-error/output/Control.Monad.Free/index.js:78:60)
    at toView (/home/miles/temp/tt/clean-error/output/Control.Monad.Free/index.js:92:23)
    at go (/home/miles/temp/tt/clean-error/output/Control.Monad.Free/index.js:236:17)
    at /home/miles/temp/tt/clean-error/output/Control.Semigroupoid/index.js:9:20
    at $tco_loop (/home/miles/temp/tt/clean-error/output/Control.Monad.Free/index.js:78:60)
    at toView (/home/miles/temp/tt/clean-error/output/Control.Monad.Free/index.js:92:23)

In "first":
  Error: expected 1, got 2
    at Object.exports.error (/home/miles/temp/tt/clean-error/output/Effect.Exception/foreign.js:8:10)
    at Object.failure (/home/miles/temp/tt/clean-error/output/Test.Unit/index.js:309:38)
    at /home/miles/temp/tt/clean-error/output/Test.Unit.Assert/index.js:40:34
    at Object.<anonymous> (/home/miles/temp/tt/clean-error/output/Test.Main/index.js:16:194)
    at Module._compile (internal/modules/cjs/loader.js:1147:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1167:10)
    at Module.load (internal/modules/cjs/loader.js:996:32)
    at Function.Module._load (internal/modules/cjs/loader.js:896:14)
    at Module.require (internal/modules/cjs/loader.js:1036:19)
    at require (internal/modules/cjs/helpers.js:72:18)

[error] Tests failed: exit code: 1
```

This test runner produces the following output instead:
```
☠ Failed: first because expected 1, got 2
✓ Passed: second
☠ Failed: third because expected 1, got 3

2 tests failed:

In "third":
  expected 1, got 3

In "first":
  expected 1, got 2

[error] Tests failed: exit code: 1
```

I'd even suggest making `NoStack` the default, and moving the current default to an opt-in `WithStack` runner.