### PR TITLE
Remove unused names and export some functions

### DIFF
--- a/src/Test/Unit/Assert.purs
+++ b/src/Test/Unit/Assert.purs
@@ -4,6 +4,7 @@ module Test.Unit.Assert
   , expectFailure
   , equal
   , equal'
+  , equal''
   , shouldEqual
   ) where
 


### PR DESCRIPTION
Removes unused name bindings, which now warn as of PureScript 0.14.1. I have also exported some functions (`xdescribe`, `xit`, etc.) that seem like they were meant to be exported (they have documentation comments), but which weren't.

With these changes `test-unit` no longer emits warnings when compiled with PureScript 0.14.1.